### PR TITLE
Add KafkaStart.bat script to main branch

### DIFF
--- a/KafkaStart.bat
+++ b/KafkaStart.bat
@@ -1,0 +1,4 @@
+@echo off
+start cmd /k "cd /d C:\kafka\kafka_2.13-3.3.1 && bin\windows\zookeeper-server-start.bat config\zookeeper.properties"
+timeout /t 5
+start cmd /k "cd /d C:\kafka\kafka_2.13-3.3.1 && bin\windows\kafka-server-start.bat config\server.properties"


### PR DESCRIPTION
This PR adds the KafkaStart.bat script for managing Kafka server startup.

## Changes:
- Added KafkaStart.bat script that:
  - Starts Zookeeper server
  - Waits 5 seconds for initialization
  - Starts Kafka server

## Files Changed:
- KafkaStart.bat (new file)

This script will help automate the Kafka server startup process on Windows systems.